### PR TITLE
Inference dependencies

### DIFF
--- a/environment_inference.yml
+++ b/environment_inference.yml
@@ -1,0 +1,25 @@
+name: hp_inference
+channels:
+  - pytorch
+  - conda-forge
+  - nodefaults
+dependencies:
+  - python=3.10
+  - pip
+  - rasterio
+  - pip:
+      - einops~=0.7
+      - geopandas==0.14.2
+      - lightning==2.1.3
+      - matplotlib
+      - numpy==1.26.3
+      - opencv-python~=4.9
+      - pandas==2.2.0
+      - seaborn==0.13.1
+      - torch==2.1.1
+      - torchvision==0.16.1
+      - torchmetrics==1.3.0
+      - timm~=0.9.12
+platforms:
+  - linux-64
+

--- a/environment_inference.yml
+++ b/environment_inference.yml
@@ -10,6 +10,7 @@ dependencies:
   - pip:
       - einops~=0.7
       - geopandas==0.14.2
+      - jupyterlab==4.0.11
       - lightning==2.1.3
       - matplotlib
       - numpy==1.26.3

--- a/requirements_inference.txt
+++ b/requirements_inference.txt
@@ -1,0 +1,12 @@
+einops~=0.7
+geopandas==0.14.2
+lightning==2.1.3
+matplotlib
+numpy==1.26.3
+opencv-python~=4.9
+pandas==2.2.0
+seaborn==0.13.1
+torch==2.1.1
+torchvision==0.16.1
+torchmetrics==1.3.0
+timm~=0.9.12

--- a/requirements_inference.txt
+++ b/requirements_inference.txt
@@ -1,5 +1,6 @@
 einops~=0.7
 geopandas==0.14.2
+jupyterlab==4.0.11
 lightning==2.1.3
 matplotlib
 numpy==1.26.3


### PR DESCRIPTION
Added a new `environment_inference.yml` and a simple pip installable `requirements_inference.txt` file. Also moved some imports in `demo_ml.ipynb`. 

You can run `pip install -r requirements_inference.txt` to get the slimmed down dependencies for inference. Also, please use the `demo_ml.ipynb` in this branch. 
